### PR TITLE
ROOT_URLCONF when wildcard subdomain

### DIFF
--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -41,7 +41,7 @@ def reverse(viewname, subdomain=None, scheme=None, args=None, kwargs=None,
     :param kwargs: named arguments used for URL reversing
     :param current_app: hint for the currently executing application
     """
-    urlconf = settings.SUBDOMAIN_URLCONFS.get(subdomain)
+    urlconf = settings.SUBDOMAIN_URLCONFS.get(subdomain, settings.ROOT_URLCONF)
 
     domain = get_domain()
     if subdomain is not None:


### PR DESCRIPTION
By default urlconf should be settings.ROOT_URLCONF when a wildcard subdomain is provided.
