### PR TITLE
When using REMOVE_WWW_FROM_DOMAIN to remove www from Site.domain, reversing URLs in templates fails

### DIFF
--- a/subdomains/middleware.py
+++ b/subdomains/middleware.py
@@ -32,11 +32,6 @@ class SubdomainMiddleware(object):
         domain, host = map(lower,
             (self.get_domain_for_request(request), request.get_host()))
 
-        prefix = 'www.'
-        if getattr(settings, 'REMOVE_WWW_FROM_DOMAIN', False) \
-                and domain.startswith(prefix):
-            domain = domain.replace(prefix, '', 1)
-
         pattern = r'^(?:(?P<subdomain>.*?)\.)?%s(?::.*)?$' % re.escape(domain)
         matches = re.match(pattern, host)
 

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -7,7 +7,14 @@ from django.core.urlresolvers import reverse as simple_reverse
 
 
 def current_site_domain():
-    return Site.objects.get_current().domain
+    domain = Site.objects.get_current().domain
+
+    prefix = 'www.'
+    if getattr(settings, 'REMOVE_WWW_FROM_DOMAIN', False) \
+            and domain.startswith(prefix):
+        domain = domain.replace(prefix, '', 1)
+
+    return domain
 
 get_domain = current_site_domain
 


### PR DESCRIPTION
Talked to you briefly on Twitter. Turns out that if you have www.example.com in the Site.domain table, reversing urls fails because it attaches the subdomain to Site.domain, leading to urls looking like subdomain.www.example.com
