### PR TITLE
Fix urlparse import for Python3

### DIFF
--- a/subdomains/compat/requestfactory.py
+++ b/subdomains/compat/requestfactory.py
@@ -3,7 +3,10 @@ Backport of `django.test.client.RequestFactory` from Django 1.3 and above.
 """
 import urllib
 from cStringIO import StringIO
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -1,5 +1,8 @@
 import functools
-from urlparse import urlunparse
+try:
+    from urlparse import urlunparse
+except ImportError:
+    from urllib.parse import urlunparse
 
 from django.conf import settings
 from django.contrib.sites.models import Site


### PR DESCRIPTION
Works fine for me under Python 3.3 with this fix.
