### PR TITLE
Empty subdomain case in template tag is not correctly processed

### DIFF
--- a/subdomains/templatetags/subdomainurls.py
+++ b/subdomains/templatetags/subdomainurls.py
@@ -38,7 +38,7 @@ def url(context, view, subdomain=UNSET, *args, **kwargs):
             subdomain = getattr(request, 'subdomain', None)
         else:
             subdomain = None
-    elif subdomain is '':
+    elif not subdomain:
         subdomain = None
 
     return reverse(view, subdomain=subdomain, args=args, kwargs=kwargs)

--- a/subdomains/tests/tests.py
+++ b/subdomains/tests/tests.py
@@ -232,6 +232,14 @@ class SubdomainTemplateTagTestCase(SubdomainTestMixin, TestCase):
         rendered = template.render(context).strip()
         self.assertEqual(rendered, 'http://%s/' % self.DOMAIN)
 
+    def test_with_empty_subdomain(self):
+        defaults = {'view': 'home'}
+        template = self.make_template('{% url view subdomain="" %}')
+
+        context = Context(defaults)
+        rendered = template.render(context).strip()
+        self.assertEqual(rendered, 'http://%s/' % self.DOMAIN)
+
     def test_with_subdomain(self):
         defaults = {'view': 'home'}
         template = self.make_template('{% url view subdomain=subdomain %}')


### PR DESCRIPTION
Hi!
Django passes django.utils.safestring.SafeText to the url template tag when using string literal to define subdomain in template.
