### PR TITLE
Fix for: subdomain IS '' against a "<class 'django.utils.safestring.S…

### DIFF
--- a/subdomains/templatetags/subdomainurls.py
+++ b/subdomains/templatetags/subdomainurls.py
@@ -37,7 +37,7 @@ def url(context, view, subdomain=UNSET, *args, **kwargs):
             subdomain = getattr(request, 'subdomain', None)
         else:
             subdomain = None
-    elif subdomain is '':
+    elif subdomain == '':
         subdomain = None
 
     return reverse(view, subdomain=subdomain, args=args, kwargs=kwargs)

--- a/subdomains/utils.py
+++ b/subdomains/utils.py
@@ -1,3 +1,4 @@
+import six
 import functools
 try:
     from urlparse import urlunparse
@@ -5,6 +6,7 @@ except ImportError:
     from urllib.parse import urlunparse
 
 from django.conf import settings
+from django.utils.functional import lazy
 from django.core.urlresolvers import reverse as simple_reverse
 
 
@@ -61,6 +63,7 @@ def reverse(viewname, subdomain=None, scheme=None, args=None, kwargs=None,
         current_app=current_app)
     return urljoin(domain, path, scheme=scheme)
 
+reverse_lazy = lazy(reverse, six.text_type)
 
 #: :func:`reverse` bound to insecure (non-HTTPS) URLs scheme
 insecure_reverse = functools.partial(reverse, scheme='http')


### PR DESCRIPTION
In the subdomains URL template tag, there is a check on the subdomain value. It defaults to UNSET, but when the user provides an empty string, it checks to see if the value IS ''. This is an issue since the string values provided to the template tag are instances of: "<class 'django.utils.safestring.SafeText'>". This check fails as an IS check. 

I changed this to a == comparison, which fixes the issue. 
