### PR TITLE
Update the middleware to be compatible with Django 1.10

### DIFF
--- a/subdomains/middleware.py
+++ b/subdomains/middleware.py
@@ -7,6 +7,12 @@ from django.utils.cache import patch_vary_headers
 
 from subdomains.utils import get_domain
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Pre Django 1.10 middleware does not require the mixin.
+    MiddlewareMixin = object
+
 
 logger = logging.getLogger(__name__)
 lower = operator.methodcaller('lower')
@@ -14,7 +20,7 @@ lower = operator.methodcaller('lower')
 UNSET = object()
 
 
-class SubdomainMiddleware(object):
+class SubdomainMiddleware(MiddlewareMixin):
     """
     A middleware class that adds a ``subdomain`` attribute to the current request.
     """


### PR DESCRIPTION
The way middleware is written in Django 1.10 has changed, luckily they've provided a mixin to allow existing mixins to continue to work with Django 1.10 as well as previous versions.

See: https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware

This branch updates the middleware to use `MiddlewareMixin`. Fixes #59.
