### PR TITLE
Added compatibility with Django 1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 dist/
 pip-log.txt
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - DJANGO='Django==1.7.*'
   - DJANGO='Django==1.8.*'
   - DJANGO='Django==1.9.*'
+  - DJANGO='Django==1.10.*'
 matrix:
   exclude:
     # Django >= 1.7 does not support Python 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: DJANGO='Django==1.8.*'
     - python: "2.6"
       env: DJANGO='Django==1.9.*'
+    - python: "2.6"
+      env: DJANGO='Django==1.10.*'
     # Django < 1.7 does not support Python 3.4
     - python: "3.4"
       env: DJANGO='Django==1.4.*'

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Full documentation can be found here: http://django-subdomains.readthedocs.org/
 Build Status
 ------------
 
-.. image:: https://secure.travis-ci.org/tkaemming/django-subdomains.png?branch=master
-   :target: http://travis-ci.org/tkaemming/django-subdomains
+.. image:: https://secure.travis-ci.org/contraslash/django-subdomains.png?branch=master
+   :target: http://travis-ci.org/contraslash/django-subdomains
 
 Tested on Python 2.6, 2.7, 3.4 and 3.5 on their supported Django versions from
-1.4 through 1.9.
+1.4 through 1.10.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,9 +34,10 @@ To set up subdomain URL routing and reversing in a Django project:
    :class:`django.middleware.common.CommonMiddleware`, the subdomain middleware
    should come before :class:`~django.middleware.common.CommonMiddleware`.
 2. Configure your ``SUBDOMAIN_URLCONFS`` dictionary in your Django settings file.
-3. Ensure that you've set up your ``SITE_ID`` in your Django settings file,
-   and that the ``Site.domain`` attribute for that site corresponds to the
-   domain name where users will be accessing your site at.
+3. Ensure that `django.contrib.sites` is in your INSTALLED_APPS, you've set up your
+   ``SITE_ID`` in your Django settings file, and that the ``Site.domain`` attribute
+   for that site corresponds to the domain name where users will be accessing your
+   site at.
 4. If you want to use the subdomain-based ``{% url %}`` template tag, add
    ``subdomains`` to your ``INSTALLED_APPS``.
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ except ImportError:
 install_requires = ['django']
 tests_require = install_requires + ['mock']
 
-setup(name='django-subdomains',
+setup(
+    name='django-subdomains',
     version=version,
     url='http://github.com/tkaemming/django-subdomains/',
     author='ted kaemming',

--- a/subdomains/middleware.py
+++ b/subdomains/middleware.py
@@ -11,7 +11,12 @@ from subdomains.utils import get_domain
 logger = logging.getLogger(__name__)
 lower = operator.methodcaller('lower')
 
-UNSET = object()
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+UNSET = MiddlewareMixin()
 
 
 class SubdomainMiddleware(object):

--- a/subdomains/tests/__init__.py
+++ b/subdomains/tests/__init__.py
@@ -17,6 +17,11 @@ if not settings.configured:
             'django.middleware.common.CommonMiddleware',
             'subdomains.middleware.SubdomainURLRoutingMiddleware',
         ),
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            }
+        ]
     )
 
 

--- a/subdomains/tests/urls/api.py
+++ b/subdomains/tests/urls/api.py
@@ -1,7 +1,20 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+    from django.conf.urls.defaults import url  # noqa
+
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    try:
+        from django.conf.urls.defaults import patterns  # noqa
+    except ImportError:
+        def patterns(*args):
+            new_patterns = []
+            for a in args:
+                if a:
+                    new_patterns.append(a)
+            return new_patterns
 
 from subdomains.tests.urls.default import urlpatterns as default_patterns
 from subdomains.tests.views import view

--- a/subdomains/tests/urls/application.py
+++ b/subdomains/tests/urls/application.py
@@ -1,7 +1,20 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+    from django.conf.urls.defaults import url  # noqa
+
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    try:
+        from django.conf.urls.defaults import patterns  # noqa
+    except ImportError:
+        def patterns(*args):
+            new_patterns = []
+            for a in args:
+                if a:
+                    new_patterns.append(a)
+            return new_patterns
 
 from subdomains.tests.urls.default import urlpatterns as default_patterns
 from subdomains.tests.views import view

--- a/subdomains/tests/urls/default.py
+++ b/subdomains/tests/urls/default.py
@@ -1,7 +1,20 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+    from django.conf.urls.defaults import url  # noqa
+
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    try:
+        from django.conf.urls.defaults import patterns  # noqa
+    except ImportError:
+        def patterns(*args):
+            new_patterns = []
+            for a in args:
+                if a:
+                    new_patterns.append(a)
+            return new_patterns
 
 from subdomains.tests.views import view
 

--- a/subdomains/tests/urls/marketing.py
+++ b/subdomains/tests/urls/marketing.py
@@ -1,7 +1,20 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url  # noqa
+    from django.conf.urls.defaults import url  # noqa
+
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    try:
+        from django.conf.urls.defaults import patterns  # noqa
+    except ImportError:
+        def patterns(*args):
+            new_patterns = []
+            for a in args:
+                if a:
+                    new_patterns.append(a)
+            return new_patterns
 
 from subdomains.tests.urls.default import urlpatterns as default_patterns
 


### PR DESCRIPTION
Django 1.10 change the way to declare middleware but add a compatibility MiddlewareMixin to help the migrations. Also patterns was removed from `django.conf.urls` and `django.conf.urls.defaults`, and allows urlpatterns variable to be simple list. So, in case patterns functions is not found, we replace with a custom function that transforms the input args in a list.