### PR TITLE
Fix python3.5 and Django 2.x issues

### DIFF
--- a/subdomains/middleware.py
+++ b/subdomains/middleware.py
@@ -7,47 +7,54 @@ from django.utils.cache import patch_vary_headers
 
 from subdomains.utils import get_domain
 
-
 logger = logging.getLogger(__name__)
 lower = operator.methodcaller('lower')
 
 UNSET = object()
+try:
+    # TODO: Find a better fix
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
 
-class SubdomainMiddleware(object):
+class SubdomainMiddleware(MiddlewareMixin):
     """
     A middleware class that adds a ``subdomain`` attribute to the current request.
     """
+
     def get_domain_for_request(self, request):
         """
         Returns the domain that will be used to identify the subdomain part
         for this request.
         """
-        return get_domain()
+        return get_domain(request)
 
     def process_request(self, request):
         """
         Adds a ``subdomain`` attribute to the ``request`` parameter.
         """
         domain, host = map(lower,
-            (self.get_domain_for_request(request), request.get_host()))
+                           (self.get_domain_for_request(request),
+                            request.get_host()))
 
         pattern = r'^(?:(?P<subdomain>.*?)\.)?%s(?::.*)?$' % re.escape(domain)
         matches = re.match(pattern, host)
-
+        
         if matches:
             request.subdomain = matches.group('subdomain')
         else:
             request.subdomain = None
             logger.warning('The host %s does not belong to the domain %s, '
-                'unable to identify the subdomain for this request',
-                request.get_host(), domain)
+                           'unable to identify the subdomain for this request',
+                           request.get_host(), domain)
 
 
 class SubdomainURLRoutingMiddleware(SubdomainMiddleware):
     """
     A middleware class that allows for subdomain-based URL routing.
     """
+
     def process_request(self, request):
         """
         Sets the current request's ``urlconf`` attribute to the urlconf
@@ -62,7 +69,7 @@ class SubdomainURLRoutingMiddleware(SubdomainMiddleware):
             urlconf = settings.SUBDOMAIN_URLCONFS.get(subdomain)
             if urlconf is not None:
                 logger.debug("Using urlconf %s for subdomain: %s",
-                    repr(urlconf), repr(subdomain))
+                             repr(urlconf), repr(subdomain))
                 request.urlconf = urlconf
 
     def process_response(self, request, response):


### PR DESCRIPTION
While using Django-subdomains, I found it didn't work in python 3.5 and Django 2.x, below patch, fixed all the issues found 