### PR TITLE
Fix SyntaxWarning "is" with a literal

### DIFF
--- a/subdomains/templatetags/subdomainurls.py
+++ b/subdomains/templatetags/subdomainurls.py
@@ -37,7 +37,7 @@ def url(context, view, subdomain=UNSET, *args, **kwargs):
             subdomain = getattr(request, 'subdomain', None)
         else:
             subdomain = None
-    elif subdomain is '':
+    elif subdomain == '':
         subdomain = None
 
     return reverse(view, subdomain=subdomain, args=args, kwargs=kwargs)


### PR DESCRIPTION
Fix the following warning:
subdomainurls.py:40: SyntaxWarning: "is" with a literal. Did you mean "=="?